### PR TITLE
Adicionada funcionalidade à grade de horarios

### DIFF
--- a/data/docentes-turmas.json
+++ b/data/docentes-turmas.json
@@ -71,7 +71,7 @@
           "periodo": "2025/1"
         },
         {
-          "turmaID": "IME04-10854 1 2025/1",
+          "turmaID": "IME04-10854 8 2025/1",
           "disciplina": "IME04-10854",
           "turma": 8,
           "periodo": "2025/1"

--- a/pagina-principal/html/subjects/timetable.inc
+++ b/pagina-principal/html/subjects/timetable.inc
@@ -1,172 +1,172 @@
 <section class="my-3 container-md">
   <div class="table-responsive">
-    <table class="table table-sm table-striped table-hover table-bordered">
-      <thead>
-        <tr>
-          <th scope="col">Tempo</th>
-          <th scope="col">Segunda</th>
-          <th scope="col">Terça</th>
-          <th scope="col">Quarta</th>
-          <th scope="col">Quinta</th>
-          <th scope="col">Sexta</th>
-          <th scope="col">Sábado</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">M1</th>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M2</th>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M3</th>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M4</th>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M5</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M6</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T1</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T2</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T3</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T4</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T5</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T6</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">N1</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">N2</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">N3</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">N4</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">N5</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
+        <table class="table table-sm table-striped table-hover table-bordered">
+          <thead>
+            <tr>
+              <th scope="col">Tempo</th>
+              <th class="SEG" scope="col">Segunda</th>
+              <th class="TER" scope="col">Terça</th>
+              <th class="QUA" scope="col">Quarta</th>
+              <th class="QUI" scope="col">Quinta</th>
+              <th class="SEX" scope="col">Sexta</th>
+              <th class="SAB" scope="col">Sábado</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th class="M1" scope="row">M1</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="M2" scope="row">M2</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="M3" scope="row">M3</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="M4" scope="row">M4</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="M5" scope="row">M5</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="M6" scope="row">M6</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T1" scope="row">T1</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T2" scope="row">T2</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T3" scope="row">T3</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T4" scope="row">T4</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T5" scope="row">T5</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="T6" scope="row">T6</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="N1" scope="row">N1</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="N2" scope="row">N2</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="N3" scope="row">N3</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="N4" scope="row">N4</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <th class="N5" scope="row">N5</th>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>

--- a/pagina-principal/js/gradeDeHorarios.js
+++ b/pagina-principal/js/gradeDeHorarios.js
@@ -1,0 +1,250 @@
+const docentesTurmasData = {
+    "docentes": [
+        {
+            "matricula": "91011-1",
+            "cpf": "123.456.789-01",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10842 1 2025/1",
+                    "disciplina": "IME04-10842",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10843 1 2025/1",
+                    "disciplina": "IME04-10843",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "23456-7",
+            "cpf": "201.302.403-11",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10832 1 2025/1",
+                    "disciplina": "IME04-10832",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10835 1 2025/1",
+                    "disciplina": "IME04-10835",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91012-2",
+            "cpf": "987.654.321-00",
+            "turmas": [
+                {
+                    "turmaID": "IME04-11311 1 2025/1",
+                    "disciplina": "IME04-11311",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-11312 1 2025/1",
+                    "disciplina": "IME04-11312",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "34578-9",
+            "cpf": "201.302.403-22",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10833 1 2025/1",
+                    "disciplina": "IME04-10833",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10836 1 2025/1",
+                    "disciplina": "IME04-10836",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10854 8 2025/1",
+                    "disciplina": "IME04-10854",
+                    "turma": 8,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91013-3",
+            "cpf": "112.233.445-56",
+            "turmas": [
+                {
+                    "turmaID": "IME01-04827 1 2025/1",
+                    "disciplina": "IME01-04827",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME02-10815 1 2025/1",
+                    "disciplina": "IME02-10815",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME02-10818 1 2025/1",
+                    "disciplina": "IME02-10818",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "56789-0",
+            "cpf": "201.302.403-33",
+            "turmas": []
+        },
+        {
+            "matricula": "91014-4",
+            "cpf": "667.788.990-00",
+            "turmas": [
+                {
+                    "turmaID": "IME01-06766 1 2025/1",
+                    "disciplina": "IME01-06766",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "56780-1",
+            "cpf": "201.302.403-44",
+            "turmas": [
+                {
+                    "turmaID": "FIS01-10982 1 2025/1",
+                    "disciplina": "FIS01-10982",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91015-5",
+            "cpf": "778.899.001-12",
+            "turmas": [
+                {
+                    "turmaID": "FIS03-10982 1 2025/1",
+                    "disciplina": "FIS03-10982",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "FIS03-10983 1 2025/1",
+                    "disciplina": "FIS03-10983",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "67890-2",
+            "cpf": "201.302.403-55",
+            "turmas": [
+                {
+                    "turmaID": "FIS01-10983 1 2025/1",
+                    "disciplina": "FIS01-10983",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        }
+    ]
+}
+
+async function preencherTabelaHorarios() {
+    try {
+        // Obter docente logado
+        const usuario = JSON.parse(localStorage.getItem('usuarioAutenticado') || "[]");
+        const docenteMatricula = usuario.matricula;
+
+        // Usar dados locais em vez de fetch
+        const docenteAtual = docentesTurmasData.docentes.find(d => d.matricula === docenteMatricula);
+
+        if (!docenteAtual) {
+            console.error("Docente não encontrado");
+            return;
+        }
+
+        // Criar mapa de turmas do docente
+        const turmasDocenteMap = new Map();
+        docenteAtual.turmas.forEach(turma => {
+            turmasDocenteMap.set(turma.turmaID, turma.turma);
+        });
+
+        // Carregar disciplinas (mantido o fetch pois não foi incorporado)
+        const disciplinas = await fetch("../../data/NOVO-disciplinas.json")
+            .then(r => r.json())
+            .then(data => data.disciplinas);
+
+        // Limpar tabela
+        document.querySelectorAll('#timetable td').forEach(td => td.textContent = '');
+
+        // Preencher tabela
+        disciplinas.forEach(disciplina => {
+            docenteAtual.turmas
+                .filter(td => td.disciplina === disciplina.codigo)
+                .forEach(turmaDocente => {
+                    const turmaDisciplina = disciplina.turmas.find(t =>
+                        t.turmaID === turmaDocente.turmaID ||
+                        (t.turmaID.includes(disciplina.codigo) &&
+                            t.turmaID.includes(` ${turmaDocente.turma} `))
+                    );
+
+                    if (turmaDisciplina) {
+                        const codigoComTurma = `${disciplina.codigo} ${numeroParaCirculado(turmaDocente.turma)}`;
+
+                        turmaDisciplina.horario.forEach(horario => {
+                            const [dia, ...periodos] = horario.split(/\s+/);
+                            const periodosFormatados = periodos.join('').match(/[A-Z]\d+/g) || [];
+
+                            periodosFormatados.forEach(periodo => {
+                                const thPeriodo = document.querySelector(`#timetable th.${periodo}`);
+                                if (!thPeriodo) return;
+
+                                const tr = thPeriodo.parentElement;
+                                const headerCells = document.querySelectorAll('#timetable thead th');
+                                const diaHeader = Array.from(headerCells).find(th =>
+                                    th.textContent.trim().toUpperCase().includes(dia.toUpperCase()) ||
+                                    th.classList.contains(dia)
+                                );
+
+                                if (diaHeader) {
+                                    const colIndex = Array.from(headerCells).indexOf(diaHeader);
+                                    const td = tr.querySelectorAll('td')[colIndex - 1];
+                                    if (td) {
+                                        td.innerHTML = td.textContent
+                                            ? `${td.innerHTML}<br>${codigoComTurma}`
+                                            : codigoComTurma;
+                                    }
+                                }
+                            });
+                        });
+                    }
+                });
+        });
+    } catch (error) {
+        console.error("Erro ao preencher tabela:", error);
+    }
+}
+
+window.preencherTabelaHorarios = preencherTabelaHorarios;
+
+
+// Função para números circulados (mantida igual)
+function numeroParaCirculado(numero) {
+    const circulados = ['⓪', '①', '②', '③', '④', '⑤', '⑥', '⑦', '⑧', '⑨', '⑩', '⑪', '⑫', '⑬', '⑭', '⑮', '⑯', '⑰', '⑱', '⑲', '⑳'];
+    if (numero >= 0 && numero <= 20) return circulados[numero];
+}

--- a/pagina-principal/subjects.html
+++ b/pagina-principal/subjects.html
@@ -1,74 +1,65 @@
 <!DOCTYPE html>
 <html lang="pt-BR">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      name="description"
-      content="Página principal do sistema de gerenciamento docente online da UERJ. Acesse a grade de disciplinas, discentes com matrícula ativa e registre notas e faltas com facilidade."
-    />
-    <link
-      rel="shortcut icon"
-      type="image/x-icon"
-      href="../../assets/svg/logo.svg"
-    />
-    <title>Docente online</title>
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr"
-      crossorigin="anonymous"
-    />
-    <link href="css/base.css" rel="stylesheet" />
-    <link href="css/header.css" rel="stylesheet" />
-    <link href="css/navbar.css" rel="stylesheet" />
-    <link href="css/list.css" rel="stylesheet" />
-    <link href="css/footer.css" rel="stylesheet" />
-    <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
-    <script>
-      $(function () {
-        $("#header").load("html/header.inc");
-      });
-      $(function () {
-        $("#navbar").load("html/main/navbar.inc");
-      });
-      $(function () {
-        $("#list").load("html/list.inc");
-      });
-      $(function () {
-        $("#search").load("html/subjects/search.inc");
-      });
-      $(function () {
-        $("#timetable").load("html/subjects/timetable.inc");
-      });
-      $(function () {
-        $("#footer").load("html/footer.inc");
-      });
-    </script>
-  </head>
-  <body>
-    <div id="header"></div>
-    <div id="navbar"></div>
-    <div id="list"></div>
-    <div
-      class="my-3 container-sm d-flex justify-content-between flex-wrap flex-column"
-    >
-      <h1>Disciplinas do Período</h1>
-      <div class="container" id="search"></div>
-    </div>
 
-    <div id="timetable"></div>
-    <div class="container">
-      <button type="button" class="btn btn-danger mt-5 btn-voltar"> Voltar</button>
-    </div>
-    <div id="footer"></div>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description"
+    content="Página principal do sistema de gerenciamento docente online da UERJ. Acesse a grade de disciplinas, discentes com matrícula ativa e registre notas e faltas com facilidade." />
+  <link rel="shortcut icon" type="image/x-icon" href="../../assets/svg/logo.svg" />
+  <title>Docente online</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/css/bootstrap.min.css" rel="stylesheet"
+    integrity="sha384-LN+7fdVzj6u52u30Kp6M/trliBMCMKTyK833zpbD+pXdCLuTusPj697FH4R/5mcr" crossorigin="anonymous" />
+  <link href="css/base.css" rel="stylesheet" />
+  <link href="css/header.css" rel="stylesheet" />
+  <link href="css/navbar.css" rel="stylesheet" />
+  <link href="css/list.css" rel="stylesheet" />
+  <link href="css/footer.css" rel="stylesheet" />
+  <script src="https://code.jquery.com/jquery-3.6.4.min.js"></script>
+  <script>
+    $(function () {
+      $("#header").load("html/header.inc");
+    });
+    $(function () {
+      $("#navbar").load("html/main/navbar.inc");
+    });
+    $(function () {
+      $("#list").load("html/list.inc");
+    });
+    $(function () {
+      $("#search").load("html/subjects/search.inc");
+    });
+    $(function () {
+      $("#timetable").load("html/subjects/timetable.inc", function () {
+        preencherTabelaHorarios();
+      });
+    });
+    $(function () {
+      $("#footer").load("html/footer.inc");
+    });;
+  </script>
+</head>
 
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q"
-      crossorigin="anonymous"
-    ></script>
-    <script type="module" src="../script/navegacaoLayoutBase.js"></script>
-    <script type="module" src="js/disciplinas.js"></script>
-  </body>
+<body>
+  <div id="header"></div>
+  <div id="navbar"></div>
+  <div id="list"></div>
+  <div class="my-3 container-sm d-flex justify-content-between flex-wrap flex-column">
+    <h1>Disciplinas do Período</h1>
+    <div class="container" id="search"></div>
+  </div>
+
+  <div id="timetable"></div>
+  <div class="container">
+    <button type="button" class="btn btn-danger mt-5 btn-voltar"> Voltar</button>
+  </div>
+  <div id="footer"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q"
+    crossorigin="anonymous"></script>
+  <script type="module" src="../script/navegacaoLayoutBase.js"></script>
+  <script src="js/gradeDeHorarios.js"></script>
+</body>
+
 </html>


### PR DESCRIPTION
1. A grade de horários preenche as células da tabela de acordo com a disciplinas atribuídas ao docente em docentes-turma.json
2. As turmas são apresentadas ao lado do código das disciplinas usando números circulados (0 a 20)
3. Os códigos das disciplinas ficam abaixo um do outro na celula
4. Corrigido bug no arquivo docentes-turmas.json onde "turmaID" da disciplina IME04-10854 turma 8 estava incorreto
5. O conteudo do arquivo docentes-turmas.json foi passado para o arquivo gradeDeHorarios.json para melhorar compatibilidade da tabela