### PR TITLE
Adicionada funcionalidade à grade de horarios (v4-final-final-ULTIMOU…

### DIFF
--- a/data/docentes-turmas.json
+++ b/data/docentes-turmas.json
@@ -95,7 +95,7 @@
           "periodo": "2025/1"
         },
         {
-          "turmaID": "IME04-10854 1 2025/1",
+          "turmaID": "IME04-10854 8 2025/1",
           "disciplina": "IME04-10854",
           "turma": 8,
           "periodo": "2025/1"

--- a/pagina-principal/html/subjects/timetable.inc
+++ b/pagina-principal/html/subjects/timetable.inc
@@ -4,71 +4,17 @@
       <thead>
         <tr>
           <th scope="col">Tempo</th>
-          <th scope="col">Segunda</th>
-          <th scope="col">Terça</th>
-          <th scope="col">Quarta</th>
-          <th scope="col">Quinta</th>
-          <th scope="col">Sexta</th>
-          <th scope="col">Sábado</th>
+          <th class="SEG" scope="col">Segunda</th>
+          <th class="TER" scope="col">Terça</th>
+          <th class="QUA" scope="col">Quarta</th>
+          <th class="QUI" scope="col">Quinta</th>
+          <th class="SEX" scope="col">Sexta</th>
+          <th class="SAB" scope="col">Sábado</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <th scope="row">M1</th>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M2</th>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td>IME04-10833</td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M3</th>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M4</th>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M5</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">M6</th>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td>IME04-10832</td>
-          <td></td>
-        </tr>
-        <tr>
-          <th scope="row">T1</th>
+          <th class="M1" scope="row">M1</th>
           <td></td>
           <td></td>
           <td></td>
@@ -77,7 +23,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">T2</th>
+          <th class="M2" scope="row">M2</th>
           <td></td>
           <td></td>
           <td></td>
@@ -86,7 +32,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">T3</th>
+          <th class="M3" scope="row">M3</th>
           <td></td>
           <td></td>
           <td></td>
@@ -95,7 +41,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">T4</th>
+          <th class="M4" scope="row">M4</th>
           <td></td>
           <td></td>
           <td></td>
@@ -104,7 +50,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">T5</th>
+          <th class="M5" scope="row">M5</th>
           <td></td>
           <td></td>
           <td></td>
@@ -113,7 +59,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">T6</th>
+          <th class="M6" scope="row">M6</th>
           <td></td>
           <td></td>
           <td></td>
@@ -122,7 +68,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">N1</th>
+          <th class="T1" scope="row">T1</th>
           <td></td>
           <td></td>
           <td></td>
@@ -131,7 +77,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">N2</th>
+          <th class="T2" scope="row">T2</th>
           <td></td>
           <td></td>
           <td></td>
@@ -140,7 +86,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">N3</th>
+          <th class="T3" scope="row">T3</th>
           <td></td>
           <td></td>
           <td></td>
@@ -149,7 +95,7 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">N4</th>
+          <th class="T4" scope="row">T4</th>
           <td></td>
           <td></td>
           <td></td>
@@ -158,7 +104,61 @@
           <td></td>
         </tr>
         <tr>
-          <th scope="row">N5</th>
+          <th class="T5" scope="row">T5</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="T6" scope="row">T6</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="N1" scope="row">N1</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="N2" scope="row">N2</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="N3" scope="row">N3</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="N4" scope="row">N4</th>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <th class="N5" scope="row">N5</th>
           <td></td>
           <td></td>
           <td></td>

--- a/pagina-principal/js/gradeDeHorarios.js
+++ b/pagina-principal/js/gradeDeHorarios.js
@@ -1,0 +1,446 @@
+const dadosCompletos = {
+    "docentes": [
+        {
+            "matricula": "91011-1",
+            "cpf": "123.456.789-01",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10842 1 2025/1",
+                    "disciplina": "IME04-10842",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10843 1 2025/1",
+                    "disciplina": "IME04-10843",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "23456-7",
+            "cpf": "201.302.403-11",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10832 1 2025/1",
+                    "disciplina": "IME04-10832",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10835 1 2025/1",
+                    "disciplina": "IME04-10835",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91012-2",
+            "cpf": "987.654.321-00",
+            "turmas": [
+                {
+                    "turmaID": "IME04-11311 1 2025/1",
+                    "disciplina": "IME04-11311",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-11312 1 2025/1",
+                    "disciplina": "IME04-11312",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "34578-9",
+            "cpf": "201.302.403-22",
+            "turmas": [
+                {
+                    "turmaID": "IME04-10833 1 2025/1",
+                    "disciplina": "IME04-10833",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10836 1 2025/1",
+                    "disciplina": "IME04-10836",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME04-10854 8 2025/1",
+                    "disciplina": "IME04-10854",
+                    "turma": 8,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91013-3",
+            "cpf": "112.233.445-56",
+            "turmas": [
+                {
+                    "turmaID": "IME01-04827 1 2025/1",
+                    "disciplina": "IME01-04827",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME02-10815 1 2025/1",
+                    "disciplina": "IME02-10815",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "IME02-10818 1 2025/1",
+                    "disciplina": "IME02-10818",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "56789-0",
+            "cpf": "201.302.403-33",
+            "turmas": []
+        },
+        {
+            "matricula": "91014-4",
+            "cpf": "667.788.990-00",
+            "turmas": [
+                {
+                    "turmaID": "IME01-06766 1 2025/1",
+                    "disciplina": "IME01-06766",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "56780-1",
+            "cpf": "201.302.403-44",
+            "turmas": [
+                {
+                    "turmaID": "FIS01-10982 1 2025/1",
+                    "disciplina": "FIS01-10982",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "91015-5",
+            "cpf": "778.899.001-12",
+            "turmas": [
+                {
+                    "turmaID": "FIS03-10982 1 2025/1",
+                    "disciplina": "FIS03-10982",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                },
+                {
+                    "turmaID": "FIS03-10983 1 2025/1",
+                    "disciplina": "FIS03-10983",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        },
+        {
+            "matricula": "67890-2",
+            "cpf": "201.302.403-55",
+            "turmas": [
+                {
+                    "turmaID": "FIS01-10983 1 2025/1",
+                    "disciplina": "FIS01-10983",
+                    "turma": 1,
+                    "periodo": "2025/1"
+                }
+            ]
+        }
+    ],
+    disciplinas: [
+        {
+            "codigo": "IME04-10842",
+            "nome": "Computação Gráfica",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10842",
+            "turmas": [ 
+                        {    
+                            "numero": 1,
+                            "turmaID": "IME04-10842 1 2025/1",
+                            "horario": ["TER M1 M2", "QUI M1 M2"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-10843",
+            "nome": "Inteligência Artificial",            
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10843",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10843 1 2025/1",
+                            "horario": ["SEG M5 M6", "QUA M5 M6"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-11312",
+            "nome": "Otimização em Grafos",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=11312",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-11312 1 2025/1",
+                            "horario": ["SEX M2 M3 M4"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-11311",
+            "nome": "Algoritmos em Grafos",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=11311",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-11311 1 2025/1",
+                            "horario": ["SEX N2N3N4"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME04-10833",
+            "nome": "Análise e Projeto de Sistemas",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10833",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10833 1 2025/1",
+                            "horario": ["TER M1M2", "QUI M1M2"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-10836",
+            "nome": "Arquitetura de Computadores II",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10836",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10836 1 2025/1",
+                            "horario": ["TER M3M4", "QUI M3M4"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME04-10854",
+            "nome": "Aspectos Práticos em Ciência da Computação I",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10854",
+            "turmas":[
+                        {
+                            "numero": 8,
+                            "turmaID": "IME04-10854 8 2025/1",
+                            "horario": ["TER M5M6", "QUI M5M6"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-10832",
+            "nome": "Banco de Dados I",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10832",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10832 1 2025/1",
+                            "horario": ["QUA M3M4", "SEX M5M6"]
+                        }
+            ]
+        },
+        {
+            "codigo": "IME04-10835",
+            "nome": "Sistemas Operacionais I",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10835",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10835 1 2025/1",
+                            "horario": ["SEG M5M6", "QUA M5M6"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME01-04827",
+            "nome": "Cálculo I",            
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=04827",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME01-04827 1 2025/1",
+                            "horario": ["SEG M5M6", "TER M5M6", "QUI M5M6"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME01-06766",
+            "nome": "Cálculo II",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=06766",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME01-06766 1 2025/1",
+                            "horario": ["SEG N1N2", "QUI N1N2"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME02-10815",
+            "nome": "Álgebra",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10815",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME02-10815 1 2025/1",
+                            "horario": ["SEG M5M6", "SEX M5M6"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME02-10818",
+            "nome": "Álgebra Linear",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10818",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME02-10818 1 2025/1",
+                            "horario": ["TER T6N1N2", "QUI T6N1N2"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "IME04-10834",
+            "nome": "Estrutura de Linguagens",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10834",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "IME04-10834 1 2025/1",
+                            "horario": ["TER M5M6", "QUI M5M6"]
+                        }
+            ]
+        },
+        {
+            "codigo": "FIS01-10982",
+            "nome": "Física I",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10982",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "FIS01-10982 1 2025/1",
+                            "horario": ["TER M1M2", "QUI M1M2", "SEX M3M4"]
+                        }
+
+            ]
+        },
+        {
+            "codigo": "FIS03-10983",
+            "nome": "Física II",
+            "ementa": "https://www.ementario.uerj.br/ementa.php?cdg_disciplina=10983",
+            "turmas":[
+                        {
+                            "numero": 1,
+                            "turmaID": "FIS03-10983 1 2025/1",
+                            "horario": ["SEG M5M6", "QUI M3M4", "SEX M5M6"]
+                        }
+                        
+            ]
+        }
+    ]
+}
+
+function preencherTabelaHorarios() {
+  try {
+    // Obter docente logado
+    const usuario = JSON.parse(localStorage.getItem('usuarioAutenticado') || "[]");
+    const docenteMatricula = usuario.matricula;
+
+    // Encontrar docente atual
+    const docenteAtual = dadosCompletos.docentes.find(d => d.matricula === docenteMatricula);
+    
+    if (!docenteAtual) {
+      console.error("Docente não encontrado");
+      return;
+    }
+
+    // Limpar tabela
+    const limparTabela = () => {
+      const cells = document.querySelectorAll('#timetable td');
+      cells.forEach(td => td.textContent = '');
+    };
+    limparTabela();
+
+    // Preencher tabela
+    docenteAtual.turmas.forEach(turmaDocente => {
+      // Encontrar disciplina correspondente
+      const disciplina = dadosCompletos.disciplinas.find(d => d.codigo === turmaDocente.disciplina);
+      if (!disciplina) return;
+
+      // Encontrar turma específica
+      const turma = disciplina.turmas.find(t => t.turmaID === turmaDocente.turmaID);
+      if (!turma) return;
+
+      // Formatar código com número circulado
+      const codigoComTurma = `${disciplina.codigo} ${numeroParaCirculado(turmaDocente.turma)}`;
+
+      // Processar horários
+      turma.horario.forEach(horario => {
+        const [dia, ...periodos] = horario.split(/\s+/);
+        const periodosFormatados = periodos.join('').match(/[A-Z]\d+/g) || [];
+        
+        periodosFormatados.forEach(periodo => {
+          const thPeriodo = document.querySelector(`#timetable th.${periodo}`);
+          if (!thPeriodo) return;
+
+          const tr = thPeriodo.parentElement;
+          const headerCells = document.querySelectorAll('#timetable thead th');
+          const diaHeader = Array.from(headerCells).find(th => 
+            th.textContent.trim().toUpperCase().includes(dia.toUpperCase()) || 
+            th.classList.contains(dia)
+          );
+          
+          if (diaHeader) {
+            const colIndex = Array.from(headerCells).indexOf(diaHeader);
+            const td = tr.querySelectorAll('td')[colIndex - 1];
+            if (td) {
+              td.innerHTML = td.textContent 
+                ? `${td.innerHTML}<br>${codigoComTurma}` 
+                : codigoComTurma;
+            }
+          }
+        });
+      });
+    });
+
+  } catch (error) {
+    console.error("Erro ao preencher tabela:", error);
+  }
+}
+
+
+window.preencherTabelaHorarios = preencherTabelaHorarios;
+
+
+// Função para números circulados (mantida igual)
+function numeroParaCirculado(numero) {
+    const circulados = ['⓪', '①', '②', '③', '④', '⑤', '⑥', '⑦', '⑧', '⑨', '⑩', '⑪', '⑫', '⑬', '⑭', '⑮', '⑯', '⑰', '⑱', '⑲', '⑳'];
+    if (numero >= 0 && numero <= 20) return circulados[numero];
+}

--- a/pagina-principal/subjects.html
+++ b/pagina-principal/subjects.html
@@ -39,7 +39,9 @@
         $("#search").load("html/subjects/search.inc");
       });
       $(function () {
-        $("#timetable").load("html/subjects/timetable.inc");
+        $("#timetable").load("html/subjects/timetable.inc", function () {
+        preencherTabelaHorarios();
+        });
       });
       $(function () {
         $("#footer").load("html/footer.inc");
@@ -69,6 +71,6 @@
       crossorigin="anonymous"
     ></script>
     <script type="module" src="../script/navegacaoLayoutBase.js"></script>
-    <script type="module" src="js/disciplinas.js"></script>
+    <script src="js/gradeDeHorarios.js"></script>
   </body>
 </html>


### PR DESCRIPTION
…PDATE)

1. A grade de horários preenche as células da tabela de acordo com a disciplinas atribuídas ao docente em docentes-turma.json
2. As turmas são apresentadas ao lado do código das disciplinas usando números circulados (0 a 20)
3. Os códigos das disciplinas ficam abaixo um do outro na celula
4. Corrigido bug no arquivo docentes-turmas.json onde "turmaID" da disciplina IME04-10854 turma 8 estava incorreto
5. O conteudo do arquivo docentes-turmas.json foi passado para o arquivo gradeDeHorarios.json para melhorar compatibilidade da tabela
6. O conteudo de NOVO-disciplinas.json também foi integrado